### PR TITLE
[FEAT] 필터링된 Snippet 리스트와 상세 페이지 추가

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -11,6 +11,8 @@ import rehypeSlug from 'rehype-slug';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 
+import rehypeCodeWrap from './src/libs/rehypeCodeWrap';
+
 const fields: FieldDefs = {
   title: { type: 'string', required: true },
   description: { type: 'string', required: true },
@@ -49,6 +51,7 @@ const contentSource = makeSource({
     remarkPlugins: [remarkGfm, remarkBreaks],
     rehypePlugins: [
       rehypeSlug,
+      rehypeCodeWrap,
       rehypePrism,
       [
         rehypeAutolinkHeadings,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "contentlayer dev & next dev",
     "build": "next build",
     "start": "next start",
     "postinstall": "husky install",

--- a/src/components/PostFooter.tsx
+++ b/src/components/PostFooter.tsx
@@ -1,10 +1,10 @@
-import { Post } from 'contentlayer/generated';
 import { motion } from 'framer-motion';
 
 import SectionBorder from '@/common/SectionBorder';
 import Tag from '@/common/Tag';
 import { fadeInHalf } from '@/constants/animations';
 import { siteConfig } from '@/constants/config';
+import { Post } from '@/types/post';
 
 import AuthorContacts from './AuthorContacts';
 import PostNavigation, { PostNavigationProps } from './PostNavigation';

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -1,4 +1,3 @@
-import { Post } from 'contentlayer/generated';
 import dayjs from 'dayjs';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -7,6 +6,7 @@ import IconText from '@/common/IconText';
 import Tag from '@/common/Tag';
 import { getRandomUnsplashImage } from '@/constants/image';
 import { $ } from '@/libs/core';
+import { Post } from '@/types/post';
 
 import CalendarIcon from './icons/CalendarIcon';
 import ClockIcon from './icons/ClockIcon';

--- a/src/components/PostNavigation.tsx
+++ b/src/components/PostNavigation.tsx
@@ -1,4 +1,4 @@
-import { Post } from 'contentlayer/generated';
+import { Post } from '@/types/post';
 
 import LinkHover from '../common/LinkHover';
 

--- a/src/components/SnippetList.tsx
+++ b/src/components/SnippetList.tsx
@@ -1,0 +1,31 @@
+import dayjs from 'dayjs';
+import Link from 'next/link';
+
+import IconText from '@/common/IconText';
+import { $ } from '@/libs/core';
+import { ReducedPost } from '@/types/post';
+
+import CalendarIcon from './icons/CalendarIcon';
+
+export default function SnippetList({ post }: { post: ReducedPost }) {
+  return (
+    <Link as={post.slug} href={`/snippets/[...slug]`}>
+      <div
+        className={$(
+          'group w-full py-4 transition-all hover:bg-neutral-200 dark:hover:bg-neutral-800',
+          'rounded-lg px-4 ring-1 ring-neutral-300 dark:ring-neutral-700',
+        )}
+      >
+        <p className="text-lg font-bold lg:text-xl">{post.title}</p>
+        <div className="mt-2 inline-flex w-full items-start gap-2 text-sm">
+          <div className="flex gap-2 whitespace-nowrap text-neutral-600 dark:text-neutral-400">
+            <IconText
+              Icon={CalendarIcon}
+              text={dayjs(post.date).format('YY.MM.DD')}
+            />
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/layouts/PostDetailLayout.tsx
+++ b/src/layouts/PostDetailLayout.tsx
@@ -1,4 +1,3 @@
-import { Post } from 'contentlayer/generated';
 import dayjs from 'dayjs';
 import { motion } from 'framer-motion';
 import { useMDXComponent } from 'next-contentlayer/hooks';
@@ -13,6 +12,7 @@ import ZoomImage from '@/components/mdx/ZoomImage';
 import PostFooter from '@/components/PostFooter';
 import { PostNavigationProps } from '@/components/PostNavigation';
 import { fadeInHalf, staggerHalf } from '@/constants/animations';
+import { Post } from '@/types/post';
 
 import Layout from './Layout';
 

--- a/src/libs/dataset.ts
+++ b/src/libs/dataset.ts
@@ -2,9 +2,21 @@ import { allPosts } from 'contentlayer/generated';
 
 import { Post } from '@/types/post';
 
+import { reducePost } from './post';
+
 export const allBlogPosts: Post[] = allPosts.filter(
   (post) =>
     !post.draft &&
     post._raw.sourceFilePath.includes('blog') &&
     !post._raw.sourceFilePath.includes('/index.mdx'),
 );
+
+export const allSnippets: Post[] = allPosts
+  .filter((post) => post._raw.sourceFilePath.includes('snippets'))
+  .map((snippet) => ({
+    ...snippet,
+    snippetName: snippet.slug.split('/').at(2) ?? null,
+  }))
+  .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+export const reducedAllSnippets = allSnippets.map(reducePost);

--- a/src/libs/post.ts
+++ b/src/libs/post.ts
@@ -1,0 +1,8 @@
+import { Post, ReducedPost } from '@/types/post';
+
+export const reducePost = ({
+  body: _,
+  _raw,
+  _id,
+  ...post
+}: Post): ReducedPost => post;

--- a/src/libs/rehypeCodeWrap.js
+++ b/src/libs/rehypeCodeWrap.js
@@ -1,0 +1,24 @@
+import { visit } from 'unist-util-visit';
+
+export default function rehypeCodeWrap() {
+  return (tree) => {
+    visit(tree, { tagName: 'pre' }, (node, index) => {
+      if (!node.children || !node.children.length) return;
+
+      // code tag
+      const { properties } = node.children[0];
+      if (!properties.className || !properties.className.length) return;
+
+      // parse code title
+      const [lang, filename] = properties.className[0]
+        .split(':')
+        .map((e) => e.trim());
+      if (filename) {
+        properties.className = lang;
+        node.properties.title = filename;
+      }
+
+      tree.children[index] = node;
+    });
+  };
+}

--- a/src/pages/blog/[...slugs].tsx
+++ b/src/pages/blog/[...slugs].tsx
@@ -23,7 +23,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   const post = allBlogPosts.find((v) => v.slug === slug);
   const postIndex = allBlogPosts.findIndex((v) => v.slug === slug);
 
-  console.log('index', postIndex);
   if (!post || postIndex < 0) {
     return {
       notFound: true,

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,4 +1,3 @@
-import { Post } from 'contentlayer/generated';
 import { motion } from 'framer-motion';
 
 import PlainText from '@/common/PlainText';
@@ -14,6 +13,7 @@ import {
 } from '@/constants/animations';
 import Layout from '@/layouts/Layout';
 import { allBlogPosts } from '@/libs/dataset';
+import { Post } from '@/types/post';
 
 export const getStaticProps = () => {
   return {

--- a/src/pages/snippets/[...slugs].tsx
+++ b/src/pages/snippets/[...slugs].tsx
@@ -1,0 +1,48 @@
+import { GetStaticPaths, GetStaticProps } from 'next';
+
+import { PostNavigationProps } from '@/components/PostNavigation';
+import PostDetailLayout, {
+  PostDetailLayoutProps,
+} from '@/layouts/PostDetailLayout';
+import { allSnippets } from '@/libs/dataset';
+
+export const getStaticPaths: GetStaticPaths = () => {
+  return {
+    paths: allSnippets
+      .filter((post) => post.snippetName)
+      .map((post) => post.slug),
+    fallback: 'blocking',
+  };
+};
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const { slugs } = params as { slugs: string[] };
+  const slug = `/snippets/${[...slugs].join('/')}`;
+
+  const post = allSnippets.find((v) => v.slug === slug);
+  const postIndex = allSnippets.findIndex((v) => v.slug === slug);
+
+  if (!post || postIndex === -1) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const postNavigation: PostNavigationProps = {
+    prevPost: postIndex > 0 ? allSnippets.at(postIndex - 1) ?? null : null,
+    nextPost: allSnippets.at(postIndex + 1) ?? null,
+  };
+
+  const props: PostDetailLayoutProps = {
+    post,
+    postNavigation,
+  };
+
+  return { props };
+};
+
+export default function PostPage({
+  ...postLayoutProps
+}: PostDetailLayoutProps) {
+  return <PostDetailLayout {...postLayoutProps} />;
+}

--- a/src/pages/snippets/index.tsx
+++ b/src/pages/snippets/index.tsx
@@ -1,12 +1,75 @@
-import { motion } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
+import { GetStaticProps } from 'next';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import title from 'title';
 
+import Pill from '@/common/Pill';
 import PlainText from '@/common/PlainText';
 import Title from '@/common/Title';
 import { PageSEO } from '@/components/SEO';
-import { fadeInHalf, staggerHalf } from '@/constants/animations';
+import SnippetList from '@/components/SnippetList';
+import {
+  fadeInHalf,
+  staggerHalf,
+  staggerImmediate,
+} from '@/constants/animations';
 import Layout from '@/layouts/Layout';
+import { reducedAllSnippets } from '@/libs/dataset';
+import { ReducedPost } from '@/types/post';
 
-export default function SnippetPage() {
+type Snippet = {
+  key: string;
+  postList: ReducedPost[];
+};
+
+export const getStaticProps: GetStaticProps = () => {
+  const tagSnippets = reducedAllSnippets.reduce<{
+    [key: string]: ReducedPost[];
+  }>((ac, snippet) => {
+    if (!snippet.snippetName) {
+      return ac;
+    }
+
+    if (!ac[snippet.snippetName]) {
+      ac[snippet.snippetName] = [];
+    }
+
+    ac[snippet.snippetName].push(snippet);
+    return ac;
+  }, {});
+
+  const snippetList = Object.keys(tagSnippets)
+    .map<Snippet>((key) => ({
+      key,
+      postList: tagSnippets[key],
+    }))
+    .sort((a, b) => b.postList.length - a.postList.length);
+
+  return {
+    props: { snippetList },
+  };
+};
+
+export default function SnippetPage({
+  snippetList,
+}: {
+  snippetList: Snippet[];
+}) {
+  const router = useRouter();
+  const selectedKey = router.query?.key;
+
+  const isAll = !selectedKey || selectedKey === 'all';
+  const allSnippetsCnt = snippetList.reduce(
+    (ac, snippet) => ac + snippet.postList.length,
+    0,
+  );
+
+  const filteredSnippetList = snippetList.filter((snippet) => {
+    if (isAll) return true;
+    return snippet.key === selectedKey;
+  });
+
   return (
     <Layout>
       <PageSEO
@@ -23,8 +86,58 @@ export default function SnippetPage() {
         exit="exit"
       >
         <motion.div variants={fadeInHalf}>
-          <PlainText>어서 내용을 채우고 싶군요 🤗</PlainText>
+          <PlainText>
+            개발하면서 실제 유용하게 사용했던 코드 조각 모음입니다.
+          </PlainText>
         </motion.div>
+        <motion.div
+          className="bg-primary sticky top-0 z-10 -mx-2 flex items-center gap-2 overflow-scroll bg-opacity-70 px-2 py-4 backdrop-blur transition-all no-scrollbar dark:bg-opacity-70"
+          variants={staggerImmediate}
+        >
+          <motion.div variants={fadeInHalf}>
+            <Link href="?key=all">
+              <Pill
+                selected={isAll}
+                className="cursor-pointer whitespace-nowrap"
+              >
+                All <span className="text-xs">{allSnippetsCnt}</span>
+              </Pill>
+            </Link>
+          </motion.div>
+          {snippetList.map(({ key, postList }) => (
+            <motion.div key={key} variants={fadeInHalf}>
+              <Link href={`?key=${key}`}>
+                <Pill
+                  className="cursor-pointer whitespace-nowrap"
+                  selected={key === selectedKey}
+                >
+                  {title(key)}{' '}
+                  <span className="text-xs">{postList.length}</span>
+                </Pill>
+              </Link>
+            </motion.div>
+          ))}
+        </motion.div>
+
+        <div className="mt-8 space-y-16">
+          {filteredSnippetList.map(({ key, postList }) => {
+            return (
+              <motion.ul
+                key={key}
+                className="mt-4 grid grid-cols-2 gap-4"
+                variants={staggerImmediate}
+              >
+                <AnimatePresence mode="wait">
+                  {postList.map((post) => (
+                    <motion.li key={post.slug} variants={fadeInHalf}>
+                      <SnippetList post={post} />
+                    </motion.li>
+                  ))}
+                </AnimatePresence>
+              </motion.ul>
+            );
+          })}
+        </div>
       </motion.div>
     </Layout>
   );


### PR DESCRIPTION
## 🌱 개요
snippet 리스트 페이지와 상세 페이지를 추가합니다.
태그 별로 필터링 된 snippet 리스트를 보여주고, 제목과 작성일을 표시합니다.
블로그 상세 페이지 컴포넌트를 재사용해서 상세 페이지를 보여줍니다.

## 🌱 작업사항
- 모든 snippet 리스트를 불러와서 SnippetList 컴포넌트를 구성합니다.
- 태그별로 snippetList를 필터링해서 볼 수 있도록 합니다.
- snippet의 제목과 작성일을 표시합니다.
- 컴포넌트를 재사용해서 snippet 상세 페이지를 보여줍니다.

## ✅ check list
- [x] 이슈 내용을 전부 적용했나요?
- [x] 산정한 작업 기간 내에 개발했나요?
