### PR TITLE
[FEAT] 반응형 목차 배너 및 상위 컨텐츠 이동 링크 추가

### DIFF
--- a/src/common/CopyLinkButton.tsx
+++ b/src/common/CopyLinkButton.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { toast } from 'react-hot-toast';
+
+import CheckIcon from '@/components/icons/CheckIcon';
+import LinkIcon from '@/components/icons/LinkIcon';
+import useWatchTimeout from '@/libs/useWatchTimeout';
+
+import IconButton from './IconButton';
+
+export default function CopyLinkButton(props: React.ComponentProps<'button'>) {
+  const [copied, setCopied] = useState(false);
+
+  useWatchTimeout(copied, 1500, () => {
+    setCopied(false);
+  });
+
+  const handleCopy = async () => {
+    const url = window.document.location.href;
+
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      toast('링크를 복사했습니다.', { icon: '🔗' });
+    } catch (e) {
+      console.error(e);
+      toast.error('링크 복사에 실패했습니다.');
+    }
+  };
+
+  return (
+    <IconButton {...props} aria-label="copy-link" onClick={handleCopy}>
+      {copied ? <CheckIcon width={20} /> : <LinkIcon width={20} />}
+    </IconButton>
+  );
+}

--- a/src/common/IconButton.tsx
+++ b/src/common/IconButton.tsx
@@ -1,0 +1,20 @@
+import { $ } from '@/libs/core';
+
+export default function IconButton({
+  className,
+  type = 'button',
+  ...props
+}: React.ComponentProps<'button'>) {
+  return (
+    <button
+      aria-label="icon-button"
+      {...props}
+      type={type}
+      className={$(
+        'flex h-9 w-9 items-center justify-center rounded-lg transition-all',
+        'text-secondary hover:bg-secondary',
+        className,
+      )}
+    />
+  );
+}

--- a/src/components/ContentsBanner.tsx
+++ b/src/components/ContentsBanner.tsx
@@ -1,0 +1,175 @@
+import { Fragment, useEffect, useState } from 'react';
+
+import CopyLinkButton from '@/common/CopyLinkButton';
+import IconButton from '@/common/IconButton';
+import UpIcon from '@/components/icons/UpIcon';
+import { $ } from '@/libs/core';
+import { Section, SubSection, TableOfContents } from '@/types/post';
+
+const useScroll = (tableOfContents: TableOfContents) => {
+  const [currentSectionSlug, setCurrentSectionSlug] = useState<
+    string | undefined
+  >();
+
+  useEffect(() => {
+    if (tableOfContents.length === 0) return;
+
+    let headings: { id: string; top: number }[];
+    const style = window.getComputedStyle(document.documentElement);
+    const scrollMt =
+      parseFloat(
+        style.getPropertyValue('--scroll-mt').match(/[\d.]+/)?.[0] ?? '0',
+      ) * parseFloat(style.fontSize.match(/[\d.]+/)?.[0] ?? '16');
+
+    function onResize() {
+      headings = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          '.prose h2:not(#table-of-contents),h3:not(#table-of-contents)',
+        ),
+      ).map((element) => ({ id: element.id, top: element.offsetTop }));
+    }
+
+    function onScroll() {
+      if (!headings) return;
+
+      const NAV_TOP = 120;
+      const top = window.pageYOffset + scrollMt - NAV_TOP + 1;
+
+      let current: typeof currentSectionSlug = undefined;
+      for (let i = 0; i < headings.length; i++) {
+        if (top >= headings[i].top) {
+          current = headings[i].id;
+        }
+      }
+      setCurrentSectionSlug(current);
+    }
+
+    onResize();
+    onScroll();
+    window.addEventListener('scroll', onScroll, {
+      capture: true,
+      passive: true,
+    });
+    window.addEventListener('resize', onResize, {
+      capture: true,
+      passive: true,
+    });
+    return () => {
+      window.removeEventListener('scroll', onScroll, { capture: true });
+      window.removeEventListener('resize', onResize, { capture: true });
+    };
+  }, [tableOfContents]);
+
+  return { tableOfContents, currentSectionSlug };
+};
+
+export default function ContentsBanner({
+  tableOfContents,
+  className,
+}: {
+  tableOfContents: TableOfContents;
+  className?: string;
+}) {
+  const { currentSectionSlug } = useScroll(tableOfContents);
+
+  const isSubSectionActive = (subSection: SubSection) => {
+    return subSection.slug === currentSectionSlug;
+  };
+
+  const isSectionActive = (section: Section) => {
+    return (
+      section.slug === currentSectionSlug ||
+      section.subSections.some((v) => v.slug === currentSectionSlug)
+    );
+  };
+
+  return (
+    <div
+      className={$(
+        'overflow-hidden rounded-xl border border-neutral-200 transition-all dark:border-neutral-800',
+        className,
+      )}
+    >
+      {tableOfContents.length !== 0 && (
+        <div className="p-4 pr-2 dark:border-neutral-700 dark:bg-neutral-800">
+          <p
+            id="toc-header"
+            className="text-primary text-sm font-extrabold leading-6"
+          >
+            On this page
+          </p>
+          <ul
+            id="toc-content"
+            className="mt-2 flex flex-col items-start justify-start text-sm"
+          >
+            {tableOfContents.map((section) => (
+              <Fragment key={section.slug}>
+                <li>
+                  <a
+                    href={`#${section.slug}`}
+                    className={$(
+                      'group block py-1',
+                      section.subSections && '',
+                      isSectionActive(section)
+                        ? 'bg-gradient-to-r from-neutral-700 to-yellow-900 bg-clip-text font-extrabold text-transparent dark:from-yellow-400 dark:to-yellow-600'
+                        : 'text-secondary hover:text-primary hover:drop-shadow-base-bold dark:hover:drop-shadow-base',
+                    )}
+                  >
+                    {section.text}
+                  </a>
+                </li>
+                {section.subSections.map((subSection) => (
+                  <li key={subSection.slug} className="ml-4">
+                    <a
+                      href={`#${subSection.slug}`}
+                      className={$(
+                        'group flex items-start py-1',
+                        isSubSectionActive(subSection)
+                          ? 'bg-gradient-to-r from-neutral-700 to-yellow-900 bg-clip-text font-extrabold text-transparent dark:from-yellow-400 dark:to-yellow-600'
+                          : 'text-secondary hover:text-primary hover:drop-shadow-base-bold dark:hover:drop-shadow-base',
+                      )}
+                    >
+                      <svg
+                        width="3"
+                        height="24"
+                        viewBox="0 -9 3 24"
+                        className={$(
+                          'mr-2 overflow-visible',
+                          'text-tertiary group-hover:text-secondary',
+                        )}
+                      >
+                        <path
+                          d="M0 0L3 3L0 6"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          strokeLinecap="round"
+                        />
+                      </svg>
+                      {subSection.text}
+                    </a>
+                  </li>
+                ))}
+              </Fragment>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div
+        className={$(
+          'flex items-center justify-end p-2',
+          'bg-neutral-150 dark:bg-neutral-750',
+        )}
+      >
+        <CopyLinkButton className="mr-auto hover:bg-mute" />
+        <IconButton
+          className="hover:bg-mute"
+          aria-label="scroll-up"
+          onClick={() => window.scrollTo({ top: 0 })}
+        >
+          <UpIcon width={20} />
+        </IconButton>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ContentsTable.tsx
+++ b/src/components/ContentsTable.tsx
@@ -1,0 +1,35 @@
+import SectionBorder from '@/common/SectionBorder';
+import { TableOfContents } from '@/types/post';
+
+export default function ContentsTable({
+  tableOfContents,
+  className,
+}: {
+  tableOfContents: TableOfContents;
+  className?: string;
+}) {
+  if (tableOfContents.length === 0) {
+    return <></>;
+  }
+
+  return (
+    <div className={className}>
+      <h2 id="table-of-contents">Table of contents</h2>
+      <ul>
+        {tableOfContents.map((section) => (
+          <li key={section.slug}>
+            <a href={`#${section.slug}`}>{section.text}</a>
+            <ul>
+              {section.subSections.map((subSection) => (
+                <li key={subSection.slug}>
+                  <a href={`#${subSection.slug}`}>{subSection.text}</a>
+                </li>
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
+      <SectionBorder />
+    </div>
+  );
+}

--- a/src/components/icons/LinkIcon.tsx
+++ b/src/components/icons/LinkIcon.tsx
@@ -1,0 +1,22 @@
+export default function LinkIcon({
+  className,
+  ...props
+}: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244"
+      />
+    </svg>
+  );
+}

--- a/src/components/icons/UpIcon.tsx
+++ b/src/components/icons/UpIcon.tsx
@@ -1,0 +1,22 @@
+export default function UpIcon({
+  className,
+  ...props
+}: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9 9l6-6m0 0l6 6m-6-6v12a6 6 0 01-12 0v-3"
+      />
+    </svg>
+  );
+}

--- a/src/layouts/PostDetailLayout.tsx
+++ b/src/layouts/PostDetailLayout.tsx
@@ -5,6 +5,8 @@ import { useMDXComponent } from 'next-contentlayer/hooks';
 import IconText from '@/common/IconText';
 import SectionBorder from '@/common/SectionBorder';
 import Title from '@/common/Title';
+import ContentsBanner from '@/components/ContentsBanner';
+import ContentsTable from '@/components/ContentsTable';
 import CalendarIcon from '@/components/icons/CalendarIcon';
 import ClockIcon from '@/components/icons/ClockIcon';
 import CodeBlock from '@/components/mdx/CodeBlock';
@@ -12,13 +14,15 @@ import ZoomImage from '@/components/mdx/ZoomImage';
 import PostFooter from '@/components/PostFooter';
 import { PostNavigationProps } from '@/components/PostNavigation';
 import { fadeInHalf, staggerHalf } from '@/constants/animations';
-import { Post } from '@/types/post';
+import { Post, Series, TableOfContents } from '@/types/post';
 
 import Layout from './Layout';
 
 export type PostDetailLayoutProps = {
   post: Post;
+  series?: Series | null;
   postNavigation: PostNavigationProps;
+  tableOfContents: TableOfContents;
 };
 
 const mdxComponents = {
@@ -28,7 +32,9 @@ const mdxComponents = {
 
 export default function PostDetailLayout({
   post,
+  series,
   postNavigation,
+  tableOfContents,
 }: PostDetailLayoutProps) {
   const MDXContent = useMDXComponent(post.body?.code ?? '');
 
@@ -59,7 +65,16 @@ export default function PostDetailLayout({
         {/* Post Content */}
         <motion.div variants={fadeInHalf} className="relative gap-8 lg:flex">
           <div className="prose prose-neutral w-full max-w-3xl font-spoqa dark:prose-dark">
+            <ContentsTable
+              className="lg:hidden"
+              tableOfContents={tableOfContents}
+            />
             <MDXContent components={mdxComponents} />
+          </div>
+          <div className="mt-12 ml-auto">
+            <div className="sticky top-[120px] hidden min-w-[240px] max-w-[260px] self-start lg:block">
+              <ContentsBanner tableOfContents={tableOfContents} />
+            </div>
           </div>
         </motion.div>
         {/* Post Footer */}

--- a/src/layouts/PostDetailLayout.tsx
+++ b/src/layouts/PostDetailLayout.tsx
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import { motion } from 'framer-motion';
+import Link from 'next/link';
 import { useMDXComponent } from 'next-contentlayer/hooks';
 
 import IconText from '@/common/IconText';
@@ -36,6 +37,10 @@ export default function PostDetailLayout({
   postNavigation,
   tableOfContents,
 }: PostDetailLayoutProps) {
+  const headerTagTitle = series?.title ?? post.snippetName;
+  const headerTagSlug =
+    series?.slug ?? `/snippets?key=${post.snippetName ?? 'all'}`;
+
   const MDXContent = useMDXComponent(post.body?.code ?? '');
 
   return (
@@ -51,6 +56,16 @@ export default function PostDetailLayout({
           <Title className="mx-auto mb-4 max-w-3xl text-center">
             {post.title}
           </Title>
+          {headerTagTitle && (
+            <div className="mt-2 flex justify-center gap-1">
+              {post.snippetName && <span>snippet: </span>}
+              <Link href={headerTagSlug}>
+                <span className="text-sm font-medium underline underline-offset-4 sm:text-base">
+                  {headerTagTitle}
+                </span>
+              </Link>
+            </div>
+          )}
           <div className="mt-2 flex w-full flex-col justify-between md:flex-row md:items-center">
             <div className="mx-auto flex gap-2 text-neutral-600 dark:text-neutral-400">
               <IconText

--- a/src/libs/mdx.ts
+++ b/src/libs/mdx.ts
@@ -1,0 +1,34 @@
+import { TableOfContents } from '@/types/post';
+
+export const parseContents = (source: string) => {
+  return source
+    .split('\n')
+    .filter((line) => line.match(/(^#{1,3})\s/))
+    .reduce<TableOfContents>((ac, rawHeading) => {
+      const nac = [...ac];
+      const removeMdx = rawHeading
+        .replace(/^##*\s/, '')
+        .replace(/[\*,\~]{2,}/g, '')
+        .replace(/(?<=\])\((.*?)\)/g, '')
+        .replace(/(?<!\S)((http)(s?):\/\/|www\.).+?(?=\s)/g, '');
+
+      const section = {
+        slug: removeMdx
+          .trim()
+          .toLowerCase()
+          .replace(/[^a-z0-9ㄱ-ㅎ|ㅏ-ㅣ|가-힣 -]/g, '')
+          .replace(/\s/g, '-'),
+        text: removeMdx,
+      };
+
+      const isSubTitle = rawHeading.split('#').length - 1 === 3;
+
+      if (ac.length && isSubTitle) {
+        nac.at(-1)?.subSections.push(section);
+      } else {
+        nac.push({ ...section, subSections: [] });
+      }
+
+      return nac;
+    }, []);
+};

--- a/src/pages/blog/[...slugs].tsx
+++ b/src/pages/blog/[...slugs].tsx
@@ -4,7 +4,9 @@ import { PostNavigationProps } from '@/components/PostNavigation';
 import PostDetailLayout, {
   PostDetailLayoutProps,
 } from '@/layouts/PostDetailLayout';
-import { allBlogPosts } from '@/libs/dataset';
+import { allBlogPosts, allSeries } from '@/libs/dataset';
+import { parseContents } from '@/libs/mdx';
+import { Series } from '@/types/post';
 
 // SSG 렌더링을 사용하기 위한 getStaticPaths 함수 사용
 export const getStaticPaths: GetStaticPaths = async () => {
@@ -34,9 +36,20 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     nextPost: allBlogPosts.at(postIndex - 1) ?? null,
   };
 
+  let series: Series | null = null;
+
+  if (post.seriesName) {
+    series =
+      allSeries.find((series) =>
+        series.slug.startsWith(`/blog/${post.seriesName}`),
+      ) ?? null;
+  }
+
   const props: PostDetailLayoutProps = {
     post,
+    series,
     postNavigation,
+    tableOfContents: parseContents(post.body.raw),
   };
 
   return {

--- a/src/pages/snippets/[...slugs].tsx
+++ b/src/pages/snippets/[...slugs].tsx
@@ -5,6 +5,7 @@ import PostDetailLayout, {
   PostDetailLayoutProps,
 } from '@/layouts/PostDetailLayout';
 import { allSnippets } from '@/libs/dataset';
+import { parseContents } from '@/libs/mdx';
 
 export const getStaticPaths: GetStaticPaths = () => {
   return {
@@ -33,9 +34,12 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     nextPost: allSnippets.at(postIndex + 1) ?? null,
   };
 
+  const tableOfContents = parseContents(post.body.raw);
+
   const props: PostDetailLayoutProps = {
     post,
     postNavigation,
+    tableOfContents,
   };
 
   return { props };

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -12,3 +12,12 @@ export type ReducedPost = Omit<Omit<Omit<Post, 'body'>, '_raw'>, '_id'>;
 export type Series = Post & {
   posts: ReducedPost[];
 };
+
+export type TableOfContents = Section[];
+export type SubSection = {
+  slug: string;
+  text: string;
+};
+export type Section = SubSection & {
+  subSections: SubSection[];
+};


### PR DESCRIPTION
## 🌱 개요
mdx의 목차를 파싱해서 글의 목차를 보여주는 반응형 배너를 추가합니다.
목차에 현재 읽고 있는 위치를 표시하고, 링크를 통해 해당 부분으로 이동할 수 있도록 합니다.
글 상단에 시리즈 및 snippet 링크를 추가해서 이동할 수 있도록 합니다.

## 🌱 작업사항
- mdx의 목차를 파싱하는 함수 추가
- 태블릿 이상의 사이즈에서는 항상 오른쪽에 sticky하게 붙어있는 배너를 보여줍니다.
- 모바일 사이즈에서는 최상단에서 배너를 보여줍니다.
- 목차 배너에서 현재 읽고 있는 목차를 표시합니다.
- 목차 리스트를 클릭하면 해당 부분으로 스크롤합니다.
- 글 상단에 시리즈 및 snippet 링크를 추가합니다.

## ✅ check list
- [x] 이슈 내용을 전부 적용했나요?
- [x] 산정한 작업 기간 내에 개발했나요?
