### PR TITLE
[FEAT] 다크 모드 설정 토글 버튼 추가

### DIFF
--- a/src/components/ThemeSwitch.tsx
+++ b/src/components/ThemeSwitch.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+import IconButton from '@/common/IconButton';
+import useDarkMode from '@/libs/useDarkMode';
+
+export default function ThemeSwitch(props: React.ComponentProps<'button'>) {
+  const [mounted, setMounted] = useState(false);
+  const { isThemeDark, toggleTheme } = useDarkMode();
+
+  useEffect(() => setMounted(true), []);
+
+  return (
+    <IconButton {...props} aria-label="Toggle Dark Mode" onClick={toggleTheme}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        className="h-6 w-6 text-yellow-400 drop-shadow-base"
+      >
+        {!mounted ? (
+          <></>
+        ) : isThemeDark ? (
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69.75.75 0 01.981.98 10.503 10.503 0 01-9.694 6.46c-5.799 0-10.5-4.701-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 01.818.162z"
+          />
+        ) : (
+          <path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.758 17.303a.75.75 0 00-1.061-1.06l-1.591 1.59a.75.75 0 001.06 1.061l1.591-1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.697 7.757a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591z" />
+        )}
+      </svg>
+    </IconButton>
+  );
+}

--- a/src/layouts/HeaderNavigation.tsx
+++ b/src/layouts/HeaderNavigation.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import LogoIcon from '@/common/LogoIcon';
+import ThemeSwitch from '@/components/ThemeSwitch';
 import { siteConfig } from '@/constants/config';
 
 import NavItem from '../common/NavItem';
@@ -23,6 +24,9 @@ export default function HeaderNavigation() {
             {link.label}
           </NavItem>
         ))}
+      </div>
+      <div className="ml-auto flex items-center gap-2">
+        <ThemeSwitch />
       </div>
     </nav>
   );

--- a/src/libs/useDarkMode.ts
+++ b/src/libs/useDarkMode.ts
@@ -1,0 +1,23 @@
+import { useTheme } from 'next-themes';
+
+export default function useDarkMode() {
+  const { resolvedTheme, setTheme } = useTheme();
+
+  const isThemeDark = resolvedTheme === 'dark';
+  const setThemeDark = () => setTheme('dark');
+  const setThemeLight = () => setTheme('light');
+
+  return {
+    theme: resolvedTheme,
+    isThemeDark,
+    setThemeDark,
+    setThemeLight,
+    toggleTheme: () => {
+      if (isThemeDark) {
+        setThemeLight();
+      } else {
+        setThemeDark();
+      }
+    },
+  };
+}


### PR DESCRIPTION
## 🌱 개요
다크 모드를 설정할 수 있는 스위치 버튼을 추가합니다.

## 🌱 작업사항
- theme을 설정하는 useDarkMode hook 추가
- 다크 모드를 켜고 끌 수 있는 토글 버튼 추가

## ✅ check list
- [ ] 이슈 내용을 전부 적용했나요?
- [ ] 산정한 작업 기간 내에 개발했나요?
