### PR TITLE
[FEAT][STYLE] Navigation bar 반응형 처리, css 적용

### DIFF
--- a/src/common/Pill.tsx
+++ b/src/common/Pill.tsx
@@ -13,9 +13,7 @@ export default function Pill({ className, selected, ...props }: PillProps) {
       className={$(
         'rounded-lg px-2 py-0.5 transition-colors',
         'bg-secondary hover:text-primary hover:bg-tertiary',
-        selected
-          ? 'text-primary font-semibold ring-2 ring-neutral-350'
-          : 'text-secondary font-normal',
+        selected ? 'text-primary ring-2 ring-neutral-350' : 'text-secondary',
         className,
       )}
     />

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -14,9 +14,9 @@ import ClockIcon from './icons/ClockIcon';
 export default function PostList({ post }: { post: ReducedPost }) {
   const href = `/blog/[...slug]`;
   return (
-    <div className={$('text-ye group w-full py-4 hover:drop-shadow-base')}>
-      <Link as={post.slug} href={href} className="hover:drop-shadow-base">
-        <div className="overflow-hidden rounded-xl bg-neutral-200 dark:bg-neutral-800 mb-3">
+    <div className={$('text-ye group w-full py-4')}>
+      <Link as={post.slug} href={href}>
+        <div className="overflow-hidden rounded-xl bg-neutral-200 dark:bg-neutral-800 mb-3 group-hover:opacity-90">
           <Image
             src={post.image ? post.image : getRandomUnsplashImage()}
             alt={'대표 이미지'}
@@ -26,7 +26,9 @@ export default function PostList({ post }: { post: ReducedPost }) {
             draggable={false}
           />
         </div>
-        <p className="text-xl font-bold">{post.title}</p>
+        <p className="text-xl font-bold group-hover:text-highlight">
+          {post.title}
+        </p>
         <p className="text-tertiary mt-1">{post.description}</p>
       </Link>
       <div className="mt-2 inline-flex w-full items-start gap-2 text-sm">
@@ -36,7 +38,7 @@ export default function PostList({ post }: { post: ReducedPost }) {
           ))}
         </div>
 
-        <div className="ml-auto flex gap-2 whitespace-nowrap group-hover:drop-shadow-base-bold">
+        <div className="ml-auto flex gap-2 whitespace-nowrap">
           <IconText
             Icon={CalendarIcon}
             text={dayjs(post.date).format('YY.MM.DD')}

--- a/src/layouts/HeaderNavigation.tsx
+++ b/src/layouts/HeaderNavigation.tsx
@@ -1,17 +1,39 @@
-import { useEffect } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 
 import LogoIcon from '@/common/LogoIcon';
 import ThemeSwitch from '@/components/ThemeSwitch';
 import { siteConfig } from '@/constants/config';
+import { $ } from '@/libs/core';
 
 import NavItem from '../common/NavItem';
 
 export default function HeaderNavigation() {
+  const router = useRouter();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
   useEffect(() => {
     return function cleanup() {
       document.body.classList.remove('overflow-hidden');
     };
   }, []);
+
+  const isActiveNav = (navPath: string) => {
+    if (navPath === '/') return router.asPath === navPath;
+
+    return router.asPath.startsWith(navPath);
+  };
+
+  const toggleMenu = () => {
+    if (isMenuOpen) {
+      setIsMenuOpen(false);
+      document.body.classList.remove('overflow-hidden');
+    } else {
+      setIsMenuOpen(true);
+      document.body.classList.add('overflow-hidden');
+    }
+  };
 
   return (
     <nav className="text-secondary flex w-full select-none items-end pt-8 pb-12">
@@ -24,6 +46,36 @@ export default function HeaderNavigation() {
             {link.label}
           </NavItem>
         ))}
+      </div>
+      <div className="flex sm:hidden">
+        <button onClick={toggleMenu}>
+          <LogoIcon width={40} />
+        </button>
+        <ul
+          className={$(
+            'transition-transform sm:translate-x-0 bg-primary absolute inset-x-0 top-[108px] -bottom-4 z-50 flex flex-col px-6 transition-all',
+            isMenuOpen ? 'opacity-100' : 'opacity-0 -translate-x-full',
+          )}
+        >
+          {[{ label: 'Home', path: '/' }, ...siteConfig.menus].map(
+            (link, i) => (
+              <Link
+                key={link.label}
+                href={link.path}
+                className={$(
+                  'border-b border-neutral-200 py-4 font-semibold transition-all dark:border-neutral-700',
+                  isMenuOpen
+                    ? 'translate-x-0 opacity-100'
+                    : '-translate-x-4 opacity-0',
+                  isActiveNav(link.path) ? 'text-yellow-400' : 'text-primary',
+                )}
+                style={{ transitionDelay: `${150 + i * 25}ms` }}
+              >
+                {link.label}
+              </Link>
+            ),
+          )}
+        </ul>
       </div>
       <div className="ml-auto flex items-center gap-2">
         <ThemeSwitch />

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -15,7 +15,7 @@ export default function Layout({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <div className="mx-auto max-w-3xl px-6 lg:max-w-6xl lg:px-8 whitespace-pre-line">
+    <div className="mx-auto max-w-3xl px-6 lg:max-w-6xl lg:px-8">
       <HeaderNavigation />
       <main className="relative pb-16">{children}</main>
       <footer className="pb-8 text-sm text-neutral-800 dark:text-neutral-400">

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,7 +4,7 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head />
-      <body>
+      <body className="text-primary bg-primary">
         <Main />
         <NextScript />
       </body>


### PR DESCRIPTION
## 🌱 개요
모바일 사이즈일 때 상단의 Navigation bar를 Side bar 형식으로 열고 닫을 수 있게 처리합니다.
전체 배경색과 text색을 primary 색으로 설정합니다.
글을 hover 했을 때 강조하는 css 속성을 추가합니다.

## 🌱 작업사항
- tailwind의 sm(640px) 사이즈 미만일 때 Side bar 형식으로 열고 닫을 수 있게 처리
- document 파일을 수정해서 전체 글자 색과 배경 색을 primary로 설정
- tailwind의 group 속성을 사용
  - 글 컴포넌트를 hover 했을 때 title 색만 highlight color로 변경
  - 글 컴포넌트를 hover 했을 때 이미지의 opacity만 변경
  
## ✅ check list
- [x] 이슈 내용을 전부 적용했나요?
- [x] 산정한 작업 기간 내에 개발했나요?
