### PR TITLE
[FEAT] 블로그 포스트 검색창 추가

### DIFF
--- a/src/common/SearchInput.tsx
+++ b/src/common/SearchInput.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { ChangeEvent, FormEvent, useState } from 'react';
 
 import { $ } from '@/libs/core';
+import useDebounce from '@/libs/useDebounce';
 
 type SearchInputProps = {
   className?: string;
@@ -16,11 +17,25 @@ export default function SearchInput({
   const isSearchPage = router.pathname === '/search';
 
   const [inputText, setInputText] = useState('');
+  const debouncedText = useDebounce(inputText);
+
+  const handleSearchQuery = () => {
+    router.push({
+      pathname: '/search',
+      query: { q: debouncedText },
+    });
+  };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (isSearchPage) {
       const value = e.target.value;
       setInputText(value);
+    }
+  };
+
+  const handleClick = () => {
+    if (!isSearchPage) {
+      handleSearchQuery();
     }
   };
 
@@ -40,6 +55,7 @@ export default function SearchInput({
         placeholder={placeholder}
         value={inputText}
         onChange={handleChange}
+        onClick={handleClick}
         autoFocus={isSearchPage}
       />
       <button

--- a/src/common/SearchInput.tsx
+++ b/src/common/SearchInput.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { ChangeEvent, FormEvent, useState } from 'react';
+import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
 
 import { $ } from '@/libs/core';
 import useDebounce from '@/libs/useDebounce';
@@ -42,6 +42,12 @@ export default function SearchInput({
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
   };
+
+  useEffect(() => {
+    if (isSearchPage) {
+      handleSearchQuery();
+    }
+  }, [debouncedText]);
 
   return (
     <form className={$('relative w-full', className)} onSubmit={handleSubmit}>

--- a/src/common/SearchInput.tsx
+++ b/src/common/SearchInput.tsx
@@ -1,0 +1,65 @@
+import { useRouter } from 'next/router';
+import { ChangeEvent, FormEvent, useState } from 'react';
+
+import { $ } from '@/libs/core';
+
+type SearchInputProps = {
+  className?: string;
+  placeholder: string;
+};
+
+export default function SearchInput({
+  className,
+  placeholder,
+}: SearchInputProps) {
+  const router = useRouter();
+  const isSearchPage = router.pathname === '/search';
+
+  const [inputText, setInputText] = useState('');
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (isSearchPage) {
+      const value = e.target.value;
+      setInputText(value);
+    }
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+  };
+
+  return (
+    <form className={$('relative w-full', className)} onSubmit={handleSubmit}>
+      <input
+        type="text"
+        className={$(
+          'block w-full rounded-md border px-4 py-2 sm:min-w-[300px]',
+          'border-neutral-200 bg-white placeholder:text-tertiary dark:border-neutral-900 dark:bg-neutral-800',
+          'focus:outline-none focus:ring-4 focus:ring-neutral-200 dark:focus:ring-neutral-800',
+        )}
+        placeholder={placeholder}
+        value={inputText}
+        onChange={handleChange}
+        autoFocus={isSearchPage}
+      />
+      <button
+        type="submit"
+        className="text-secondary absolute right-3 top-3 h-5 w-5"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+      </button>
+    </form>
+  );
+}

--- a/src/components/HoverCard.tsx
+++ b/src/components/HoverCard.tsx
@@ -63,7 +63,6 @@ export default function HoverCard({
           justify-content: center;
           align-items: center;
           perspective: 800px;
-          padding: 50px;
         }
 
         .card {

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -1,10 +1,11 @@
 import dayjs from 'dayjs';
 import Image from 'next/image';
 import Link from 'next/link';
+import React from 'react';
 
 import IconText from '@/common/IconText';
 import Tag from '@/common/Tag';
-import { getRandomUnsplashImage } from '@/constants/image';
+import { defaultCoverImage } from '@/constants/image';
 import { $ } from '@/libs/core';
 import { ReducedPost } from '@/types/post';
 
@@ -13,12 +14,13 @@ import ClockIcon from './icons/ClockIcon';
 
 export default function PostList({ post }: { post: ReducedPost }) {
   const href = `/blog/[...slug]`;
+
   return (
     <div className={$('text-ye group w-full py-4')}>
       <Link as={post.slug} href={href}>
         <div className="overflow-hidden rounded-xl bg-neutral-200 dark:bg-neutral-800 mb-3 group-hover:opacity-90">
           <Image
-            src={post.image ? post.image : getRandomUnsplashImage()}
+            src={post.image ?? defaultCoverImage}
             alt={'대표 이미지'}
             width={300}
             height={300}

--- a/src/constants/image.ts
+++ b/src/constants/image.ts
@@ -23,3 +23,5 @@ export const unsplashImageList = [
 
 export const getRandomUnsplashImage = () =>
   [...unsplashImageList].sort(() => Math.random() - 0.5)[0];
+
+export const defaultCoverImage = '/images/samples/unsplash-16.jpg';

--- a/src/layouts/HeaderNavigation.tsx
+++ b/src/layouts/HeaderNavigation.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 import LogoIcon from '@/common/LogoIcon';
+import SearchInput from '@/common/SearchInput';
 import ThemeSwitch from '@/components/ThemeSwitch';
 import { siteConfig } from '@/constants/config';
 import { $ } from '@/libs/core';
@@ -12,12 +13,6 @@ import NavItem from '../common/NavItem';
 export default function HeaderNavigation() {
   const router = useRouter();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-
-  useEffect(() => {
-    return function cleanup() {
-      document.body.classList.remove('overflow-hidden');
-    };
-  }, []);
 
   const isActiveNav = (navPath: string) => {
     if (navPath === '/') return router.asPath === navPath;
@@ -34,6 +29,12 @@ export default function HeaderNavigation() {
       document.body.classList.add('overflow-hidden');
     }
   };
+
+  useEffect(() => {
+    return function cleanup() {
+      document.body.classList.remove('overflow-hidden');
+    };
+  }, []);
 
   return (
     <nav className="text-secondary flex w-full select-none items-end pt-8 pb-12">
@@ -78,6 +79,7 @@ export default function HeaderNavigation() {
         </ul>
       </div>
       <div className="ml-auto flex items-center gap-2">
+        <SearchInput placeholder="포스트 제목 검색" />
         <ThemeSwitch />
       </div>
     </nav>

--- a/src/layouts/SearchLayout.tsx
+++ b/src/layouts/SearchLayout.tsx
@@ -1,0 +1,73 @@
+import { motion } from 'framer-motion';
+
+import PlainText from '@/common/PlainText';
+import SubTitle from '@/common/SubTitle';
+import Title from '@/common/Title';
+import PostList from '@/components/PostList';
+import { PageSEO } from '@/components/SEO';
+import {
+  fadeIn,
+  fadeInHalf,
+  fadeInUp,
+  staggerHalf,
+} from '@/constants/animations';
+import Layout from '@/layouts/Layout';
+import { Post } from '@/types/post';
+
+export default function SearchLayout({
+  postList,
+  searchQuery,
+}: {
+  postList: Post[];
+  searchQuery: string;
+}) {
+  return (
+    <Layout>
+      <PageSEO
+        title="search"
+        description="포스트 검색 결과입니다."
+        url="/search"
+      />
+      <Title>Search</Title>
+
+      <motion.div
+        variants={staggerHalf}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+      >
+        <motion.div
+          className="mt-8 mb-4 flex items-end gap-2"
+          variants={fadeInHalf}
+        >
+          <SubTitle>{searchQuery ? 'Filtered Posts' : 'All Posts'}</SubTitle>
+          <span className="font-bold">({postList.length})</span>
+        </motion.div>
+
+        <motion.div
+          className="grid w-full gap-8 lg:grid-cols-2 lg:gap-12"
+          variants={staggerHalf}
+        >
+          {postList.length == 0 && (
+            <div className="min-h-[300px] flex items-center mx-auto mt-4">
+              <PlainText>검색된 내용이 없습니다.</PlainText>
+            </div>
+          )}
+          {postList.map((post) => (
+            <motion.div key={post.slug} variants={fadeInUp}>
+              <motion.div
+                variants={fadeIn}
+                initial="initial"
+                whileInView="animate"
+                exit="exit"
+                viewport={{ amount: 0.2, once: true }}
+              >
+                <PostList post={post} />
+              </motion.div>
+            </motion.div>
+          ))}
+        </motion.div>
+      </motion.div>
+    </Layout>
+  );
+}

--- a/src/libs/dataset.ts
+++ b/src/libs/dataset.ts
@@ -1,5 +1,6 @@
 import { allPosts } from 'contentlayer/generated';
 
+import { defaultCoverImage } from '@/constants/image';
 import { Post, Series } from '@/types/post';
 
 import { reducePost } from './post';
@@ -17,6 +18,7 @@ export const allBlogPosts: Post[] = allPosts
   )
   .map((post) => ({
     ...post,
+    image: post.image ? post.image : defaultCoverImage,
     seriesName:
       allSeriesName.find((seriesName) => post.slug.includes(seriesName)) ??
       null,

--- a/src/libs/useDebounce.ts
+++ b/src/libs/useDebounce.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+const useDebounce = <T>(value: T, delay = 500) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timerId = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timerId);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import PlainText from '@/common/PlainText';
 import SubTitle from '@/common/SubTitle';
 import Title from '@/common/Title';
+import HoverCard from '@/components/HoverCard';
 import PostList from '@/components/PostList';
 import { PageSEO } from '@/components/SEO';
 import {
@@ -46,38 +47,49 @@ export default function BlogPage({
         exit="exit"
       >
         <motion.div variants={fadeInHalf}>
-          <PlainText>{`개발에 필요한 지식들을 소소하게 기록하는 공간입니다.
-                      시리즈로 연재된 글은 아래의 시리즈 북을 통해 열람할 수 있습니다. 🙌`}</PlainText>
+          <PlainText>
+            {`개발에 필요한 지식들을 소소하게 기록하는 공간입니다.`}
+            <br />
+            {`시리즈로 연재된 글은 아래의 시리즈 북을 통해 열람할 수 있습니다. 🙌`}
+          </PlainText>
+        </motion.div>
+        <motion.div variants={fadeInHalf}>
+          <motion.div className="mt-10 mb-4 flex items-end gap-2">
+            <SubTitle>{'All Series'}</SubTitle>
+            <span className="font-bold">({seriesList.length})</span>
+          </motion.div>
+          <motion.div
+            className="-my-12 -ml-8 flex items-center space-x-6 overflow-scroll py-12 pl-8 no-scrollbar"
+            variants={staggerOne}
+          >
+            <AnimatePresence mode="wait">
+              {seriesList.map((series) => (
+                <motion.div key={series.slug} variants={fadeInSlideToLeft}>
+                  <Link as={series.slug} href={`/blog/[slug]`}>
+                    <HoverCard>
+                      <div className="relative h-56 w-40 select-none rounded-lg bg-neutral-200 px-8 pt-8 pb-12 shadow-lg transition-all hover:scale-[1.01] hover:shadow-xl dark:bg-neutral-800">
+                        <div className="absolute inset-y-0 left-2.5 w-[1px] bg-neutral-100 dark:bg-neutral-700" />
+                        <div className="flex h-full break-keep bg-white px-2 py-3 text-sm font-medium dark:bg-neutral-700 dark:text-white">
+                          {series.title}
+                        </div>
+                      </div>
+                    </HoverCard>
+                  </Link>
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          </motion.div>
         </motion.div>
         <motion.div
-          className="-my-12 -ml-8 flex items-center space-x-6 overflow-scroll py-12 pl-8 no-scrollbar"
-          variants={staggerOne}
-        >
-          <AnimatePresence mode="wait">
-            {seriesList.map((series) => (
-              <motion.div key={series.slug} variants={fadeInSlideToLeft}>
-                <Link as={series.slug} href={`/blog/[slug]`}>
-                  <div className="relative h-56 w-40 select-none rounded-lg bg-neutral-200 px-8 pt-8 pb-12 shadow-lg transition-all hover:scale-[1.01] hover:shadow-xl dark:bg-neutral-800">
-                    <div className="absolute inset-y-0 left-2.5 w-[1px] bg-neutral-100 dark:bg-neutral-700" />
-                    <div className="flex h-full break-keep bg-white px-2 py-3 text-sm font-medium dark:bg-neutral-700 dark:text-white">
-                      {series.title}
-                    </div>
-                  </div>
-                </Link>
-              </motion.div>
-            ))}
-          </AnimatePresence>
-        </motion.div>
-        <motion.div
-          className="mt-16 mb-4 flex items-end gap-2"
+          className="pt-8 mt-8 mb-4 flex items-end gap-2"
           variants={fadeInHalf}
         >
-          <SubTitle>All Posts</SubTitle>
+          <SubTitle>{'All Posts'}</SubTitle>
           <span className="font-bold">({postList.length})</span>
         </motion.div>
 
         <motion.div
-          className="mt-12 grid w-full gap-8 lg:grid-cols-2 lg:gap-12"
+          className="grid w-full gap-8 lg:grid-cols-2 lg:gap-12"
           variants={staggerHalf}
         >
           {postList.map((post) => (
@@ -87,7 +99,7 @@ export default function BlogPage({
                 initial="initial"
                 whileInView="animate"
                 exit="exit"
-                viewport={{ amount: 0.6, once: true }}
+                viewport={{ amount: 0.2, once: true }}
               >
                 <PostList post={post} />
               </motion.div>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,0 +1,43 @@
+import { GetStaticProps } from 'next';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+import SearchLayout from '@/layouts/SearchLayout';
+import { allBlogPosts } from '@/libs/dataset';
+import { Post } from '@/types/post';
+
+export const getStaticProps: GetStaticProps = () => {
+  return {
+    props: {
+      postList: allBlogPosts,
+    },
+  };
+};
+
+export default function SearchPage({ postList }: { postList: Post[] }) {
+  const router = useRouter();
+  const searchQuery = (router.query?.q as string) || '';
+  const [filteredPosts, setFilteredPosts] = useState<Post[]>([]);
+
+  const isDiffObjectList = (list1: Post[], list2: Post[]) => {
+    if (list1.length !== list2.length) return true;
+
+    const sameList = list1.filter((item1) =>
+      list2.filter((item2) => item2.slug === item1.slug),
+    );
+
+    if (sameList.length === list1.length) return false;
+    return true;
+  };
+
+  useEffect(() => {
+    const filteredList = postList.filter((post) =>
+      post.title.toLowerCase().includes(searchQuery.toLowerCase()),
+    );
+    if (isDiffObjectList(filteredPosts, filteredList)) {
+      setFilteredPosts(filteredList);
+    }
+  }, [searchQuery]);
+
+  return <SearchLayout postList={filteredPosts} searchQuery={searchQuery} />;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,6 +25,9 @@ module.exports = {
           800: '#262626',
           900: '#171717',
         },
+        highlight: {
+          blue: '#0091ea',
+        },
       },
       dropShadow: {
         base: '0px 0px 10px rgba(234, 179, 8, 0.3)',
@@ -81,6 +84,9 @@ module.exports = {
         },
         '.text-mute': {
           '@apply text-neutral-500 dark:text-neutral-470': '',
+        },
+        '.text-highlight': {
+          '@apply text-highlight-blue': '',
         },
         '.bg-primary': {
           '@apply bg-neutral-50 dark:bg-neutral-900': '',


### PR DESCRIPTION
## 🌱 개요
블로그 글을 검색하는 검색창을 추가합니다.
debounce를 적용해서 과도한 요청을 방지하여 검색 성능을 높입니다.

검색창을 클릭하면 검색 페이지로 이동하고 검색된 PostList를 보여줍니다.
PostList 객체 배열을 비교해서 배열이 달라졌을 때만 자식 객체에 전달하여 불필요한 렌더링을 줄입니다.

## 🌱 작업 사항
- 반응형 검색창 컴포넌트 추가
- debounce hook을 만들어서 검색창에 debounce를 적용합니다.
- 검색 페이지에서 검색어에 맞게 필터링된 PostList를 보여줍니다.
- PostList 객체 배열을 비교하여 PostList가 달라졌을 때만 배열을 변경하여 새로 렌더링을 합니다.

## ✅ check list
- [x] 이슈 내용을 전부 적용했나요?
- [x] 산정한 작업 기간 내에 개발했나요?
