### PR TITLE
[FEAT][FIX] 404 페이지 추가

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,23 @@
+import NavItem from '@/common/NavItem';
+import Title from '@/common/Title';
+import { PageSEO } from '@/components/SEO';
+import Layout from '@/layouts/Layout';
+
+export default function NotFound() {
+  return (
+    <Layout>
+      <PageSEO title="404" />
+      <div className="mb-16">
+        <Title>404</Title>
+        <p className="text-secondary mb-8">찾을 수 없는 페이지입니다. 🥲</p>
+
+        <NavItem
+          href="/blog"
+          className="rounded-md px-4 py-2 ring-1 ring-neutral-400/70"
+        >
+          블로그로 돌아가기
+        </NavItem>
+      </div>
+    </Layout>
+  );
+}

--- a/src/pages/blog/[...slugs].tsx
+++ b/src/pages/blog/[...slugs].tsx
@@ -12,8 +12,7 @@ import { Series } from '@/types/post';
 export const getStaticPaths: GetStaticPaths = async () => {
   return {
     paths: allBlogPosts.map((post) => post.slug),
-    // 현재 등록된 글 이외의 제목이 전달될경우 404 처리
-    fallback: true,
+    fallback: 'blocking',
   };
 };
 


### PR DESCRIPTION
## 🌱 개요
fallback이 true로 설정되어 있어서 getStaticProps이 동작하기 때문에 존재하지 않는 페이지에서 undefined 값을 참조하는 문제가 있었습니다.
fallback을 'blocking'으로 수정하고, 404 페이지 컴포넌트를 추가해서 해결하였습니다.

## 🌱 작업사항
* fallback을 true에서 blocking으로 수정
* 404 페이지 컴포넌트 추가

## ✅ check list
- [x] 이슈 내용을 전부 적용했나요?
- [x] 산정한 작업 기간 내에 개발했나요?
