### PR TITLE
[FEAT] 사이트 도메인 변경, 깃허브 프로필 배율 변경

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-  siteUrl: 'https://pysoo.vercel.app',
+  siteUrl: 'https://enjoydev.life',
   changefreq: 'daily',
   priority: 0.7,
   sitemapSize: 7000,

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -5,7 +5,7 @@ export const BASE_PATH = '/posts';
 export const POSTS_PATH = path.join(process.cwd(), BASE_PATH);
 
 export const siteConfig = {
-  url: 'https://pySoo.github.io',
+  url: 'https://enjoydev.life',
   title: '기억은 기록을 이기지 못한다 ✍️',
   description:
     '꾸준함과 글쓰기를 좋아하는 프론트엔드 개발자입니다. 웹 개발 지식과 JavaScript 지식을 쉽게 풀어 쓰는 활동을 하고 있습니다.',

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -14,7 +14,7 @@ export const siteConfig = {
   googleAnalyticsId: '',
   author: {
     name: 'Suhyeon Park',
-    photo: 'https://avatars.githubusercontent.com/u/55135881?s=96&v=4',
+    photo: 'https://avatars.githubusercontent.com/u/55135881?s=288&v=4',
     bio: 'Junior Frontend Engineer',
     contacts: {
       email: 'soopy368@gmail.com',


### PR DESCRIPTION
## 🌱 개요
블로그 브랜딩화(?) 및 각인 효과를 위해 도메인을 변경합니다. ✨
기본 도메인 pysoo.vercel.app 에서 enjoydev.life로 도메인을 변경합니다. 
깃허브 프로필 사진이 깨지는 현상이 있어서 3배율로 설정합니다.

## 🌱 작업사항
- config 파일 및 sitemap 설정에서 쓰이는 도메인 주소를 변경합니다.
- 깃허브 프로필 사진 사이즈를 조정합니다.

## 🌱 예상기간
7월13일 ~ 7월13일

## ✅ check list
- [x] 이슈 내용을 전부 적용했나요?
- [x] 산정한 작업 기간 내에 개발했나요?
