### PR TITLE
[FIX][STYLE] 사파리 버그 수정, 모바일 css 대응

### DIFF
--- a/src/components/PostNavigation.tsx
+++ b/src/components/PostNavigation.tsx
@@ -20,7 +20,7 @@ export default function PostNavigation({
         >
           <svg
             viewBox="0 0 3 6"
-            className="w-fit text-mute h-1.5 overflow-visible group-hover:text-secondary"
+            className="text-mute h-1.5 overflow-visible group-hover:text-secondary"
           >
             <path
               d="M3 0L0 3L3 6"

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -16,7 +16,7 @@ export default function Layout({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <div className="mx-auto max-w-3xl px-6 lg:max-w-6xl lg:px-8">
+    <div className="mx-auto max-w-3xl px-6 lg:max-w-6xl lg:px-8 overflow-x-hidden">
       <HeaderNavigation />
       <main className="relative pb-16">{children}</main>
       <footer className="pb-8 text-sm text-neutral-800 dark:text-neutral-400">

--- a/src/libs/dataset.ts
+++ b/src/libs/dataset.ts
@@ -30,7 +30,7 @@ export const allSnippets: Post[] = allPosts
   .filter((post) => post._raw.sourceFilePath.includes('snippets'))
   .map((snippet) => ({
     ...snippet,
-    snippetName: snippet.slug.split('/').at(2) ?? null,
+    snippetName: snippet.slug.split('/')[2] ?? null,
   }))
   .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 


### PR DESCRIPTION
## 🌱 개요
사파리 홈 화면에서 at() 메서드 사용 시 에러가 발생해서 index로 접근하도록 코드를 수정합니다.
모바일 환경에서 특정 페이지에서 가로 스크롤이 되는 이슈가 있어서 가로 스크롤을 막습니다.
모바일 환경에서 글 이동 네비게이션 바가 잘려서 나오는 이슈를 수정합니다.

## 🌱 작업사항
- 홈 화면에서 사용하는 at 메서드를 index 접근으로 변경
- Layout 컴포넌트에 overflow-x-hidden css 추가
- 네비게이션 바에서 사용하는 w-fit css 제거

## ✅ check list
- [ ] 이슈 내용을 전부 적용했나요?
- [ ] 산정한 작업 기간 내에 개발했나요?
