### PR TITLE
[FEAT][STYLE] fonts 및 font loaders 적용, css 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,4 +4,9 @@ const { withContentlayer } = require('next-contentlayer');
 module.exports = withContentlayer({
   reactStrictMode: true,
   swcMinify: false,
+  experimental: {
+    fontLoaders: [
+      { loader: '@next/font/google', options: { subsets: ['latin'] } },
+    ],
+  },
 });

--- a/posts/snippets/git/alias.mdx
+++ b/posts/snippets/git/alias.mdx
@@ -16,7 +16,7 @@ Git 명령어를 단축키를 등록해서 간단하게 사용할 수 있게 해
 
 ### 1. **Git Commands로 설정하기**
 
-- **git config** 를 사용하여 각 명령의 Alias을 쉽게 만들 수 있습니다.
+- **git config**를 사용하여 각 명령의 Alias을 쉽게 만들 수 있습니다.
 
 ```bash
 git config --global alias.st 'status -s'

--- a/src/common/Fonts.tsx
+++ b/src/common/Fonts.tsx
@@ -1,0 +1,14 @@
+import { fontMono, fontSans } from '@/constants/fonts';
+
+export default function Fonts() {
+  return (
+    <>
+      <style jsx global>{`
+        :root {
+          --font-sans: ${fontSans.style.fontFamily};
+          --font-mono: ${fontMono.style.fontFamily};
+        }
+      `}</style>
+    </>
+  );
+}

--- a/src/constants/fonts.ts
+++ b/src/constants/fonts.ts
@@ -1,0 +1,16 @@
+import {
+  Inter as FontSans,
+  JetBrains_Mono as FontMono,
+} from '@next/font/google';
+
+export const fontSans = FontSans({
+  subsets: ['latin'],
+  variable: '--font-sans',
+  display: 'swap',
+});
+
+export const fontMono = FontMono({
+  subsets: ['latin'],
+  variable: '--font-mono',
+  display: 'swap',
+});

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -16,7 +16,7 @@ export default function Layout({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <div className="mx-auto max-w-3xl px-6 lg:max-w-6xl lg:px-8 overflow-x-hidden">
+    <div className="mx-auto max-w-3xl px-6 lg:max-w-6xl lg:px-8">
       <HeaderNavigation />
       <main className="relative pb-16">{children}</main>
       <footer className="pb-8 text-sm text-neutral-800 dark:text-neutral-400">

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import Script from 'next/script';
 import { DefaultSeo } from 'next-seo';
 import { ThemeProvider } from 'next-themes';
 
+import Fonts from '@/common/Fonts';
 import { seoConfig } from '@/constants/config';
 import { $, isDev } from '@/libs/core';
 import * as gtag from '@/libs/gtag';
@@ -19,6 +20,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       </Head>
       <DefaultSeo {...seoConfig} />
+      <Fonts />
       <div className={$('font-sans break-keep')}>
         <Component {...pageProps} />
       </div>

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -81,3 +81,8 @@
 .prose *:hover > .anchor {
   @apply md:opacity-100;
 }
+
+.prose ul,
+.prose ol {
+  padding-left: 1.2rem;
+}


### PR DESCRIPTION
## 🌱 개요
데스크탑 사파리에서 폰트 인식을 못 하는 이슈가 있어서 google fonts를 적용했습니다.
폰트를 preload 할 수 있도록 font loaders의 subsets 속성을 지정해서 성능을 개선했습니다.
목차 배너의 sticky 속성이 작동하지 않아서 상위 컴포넌트의 overflow 속성을 제거했습니다.
ul, ol 태그의 왼쪽 패딩을 줄였습니다.

## 🌱 작업사항
* next/font/google을 이용해서 google fonts를 적용했습니다.
* font loaders의 subsets 속성을 지정해서 폰트를 preload 했습니다.
* 목차 배너의 sticky 속성이 작동하지 않아서 상위 컴포넌트의 overflow 속성을 제거했습니다.
* ul, ol 태그의 왼쪽 패딩을 줄였습니다.

## ✅ check list
- [x] 이슈 내용을 전부 적용했나요?
- [x] 산정한 작업 기간 내에 개발했나요?
