### PR TITLE
[FEAT][STYLE] 태그 링크 제거, Snippet 리스트에서 readingTime 보여주기

### DIFF
--- a/src/common/Tag.tsx
+++ b/src/common/Tag.tsx
@@ -1,12 +1,7 @@
-import Link from 'next/link';
 import title from 'title';
 
 import Pill from './Pill';
 
 export default function Tag({ tag }: { tag: string }) {
-  return (
-    <Link href={`/archives/tags/${tag}`}>
-      <Pill>{title(tag)}</Pill>
-    </Link>
-  );
+  return <Pill>{title(tag)}</Pill>;
 }

--- a/src/components/ContentsBanner.tsx
+++ b/src/components/ContentsBanner.tsx
@@ -114,7 +114,7 @@ export default function ContentsBanner({
                       section.subSections && '',
                       isSectionActive(section)
                         ? 'bg-gradient-to-r from-neutral-700 to-yellow-900 bg-clip-text font-extrabold text-transparent dark:from-yellow-400 dark:to-yellow-600'
-                        : 'text-secondary hover:text-primary hover:drop-shadow-base-bold dark:hover:drop-shadow-base',
+                        : 'text-secondary hover:text-primary hover:drop-shadow-base dark:hover:drop-shadow-base',
                     )}
                   >
                     {section.text}
@@ -129,7 +129,7 @@ export default function ContentsBanner({
                           'group flex items-start py-1',
                           isSubSectionActive(subSection)
                             ? 'bg-gradient-to-r from-neutral-700 to-yellow-900 bg-clip-text font-extrabold text-transparent dark:from-yellow-400 dark:to-yellow-600'
-                            : 'text-secondary hover:text-primary hover:drop-shadow-base-bold dark:hover:drop-shadow-base',
+                            : 'text-secondary hover:text-primary hover:drop-shadow-base dark:hover:drop-shadow-base',
                         )}
                       >
                         <svg

--- a/src/components/PostFooter.tsx
+++ b/src/components/PostFooter.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
 
+import LinkExternal from '@/common/LinkExternal';
 import SectionBorder from '@/common/SectionBorder';
 import Tag from '@/common/Tag';
 import { fadeInHalf } from '@/constants/animations';
@@ -17,7 +18,7 @@ type PostFooterType = {
 
 export default function PostFooter({ post, postNavigation }: PostFooterType) {
   return (
-    <motion.div variants={fadeInHalf} className="mt-12 space-y-8 lg:mt-24">
+    <motion.div variants={fadeInHalf} className="space-y-8 mt-12">
       <div className="flex gap-2">
         {post.tags.map((tag) => (
           <Tag key={tag} tag={tag} />
@@ -26,14 +27,16 @@ export default function PostFooter({ post, postNavigation }: PostFooterType) {
       <SectionBorder />
       <div className="flex w-full items-center justify-center">
         <div className="flex items-center gap-4 sm:gap-8 sm:p-12">
-          <div>
+          <LinkExternal
+            href={`https://github.com/${siteConfig.author.contacts.github}`}
+          >
             <img
               src={siteConfig.author.photo}
               className="h-24 w-24 select-none overflow-hidden rounded-full"
               alt="프로필 사진"
               draggable={false}
             />
-          </div>
+          </LinkExternal>
           <div>
             <div className="font-bold">{siteConfig.author.name}</div>
             <div className="text-tertiary text-sm">{siteConfig.author.bio}</div>

--- a/src/components/SeriesCard.tsx
+++ b/src/components/SeriesCard.tsx
@@ -28,7 +28,7 @@ export default function SeriesCard({
   return (
     <div
       className={$(
-        'bg-secondary rounded-lg p-4 my-5',
+        'bg-secondary rounded-lg p-4 mt-12',
         !open && 'cursor-pointer transition-all hover:bg-tertiary',
       )}
       onClick={onClickCard}

--- a/src/components/SnippetList.tsx
+++ b/src/components/SnippetList.tsx
@@ -6,6 +6,7 @@ import { $ } from '@/libs/core';
 import { ReducedPost } from '@/types/post';
 
 import CalendarIcon from './icons/CalendarIcon';
+import ClockIcon from './icons/ClockIcon';
 
 export default function SnippetList({ post }: { post: ReducedPost }) {
   return (
@@ -19,12 +20,13 @@ export default function SnippetList({ post }: { post: ReducedPost }) {
         <p className="text-lg font-bold lg:text-xl line-clamp-4">
           {post.title}
         </p>
-        <div className="mt-2 inline-flex w-full items-start gap-2 text-sm">
+        <div className="mt-2 w-full flex justify-end gap-2 text-sm">
           <div className="flex gap-2 whitespace-nowrap text-neutral-600 dark:text-neutral-400">
             <IconText
               Icon={CalendarIcon}
               text={dayjs(post.date).format('YY.MM.DD')}
             />
+            <IconText Icon={ClockIcon} text={`${post.readingMinutes}분`} />
           </div>
         </div>
       </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,8 +30,7 @@ module.exports = {
         },
       },
       dropShadow: {
-        base: '0px 0px 10px rgba(234, 179, 8, 0.3)',
-        'base-bold': '0px 0px 7px rgba(234, 179, 8, 0.7)',
+        base: '0px 0px 4px rgba(240, 186, 31, 0.75)',
       },
       fontFamily: {
         sans: ['var(--font-sans)', ...fontFamily.sans],


### PR DESCRIPTION
## 🌱 개요
Google Search sitemaps 등록 과정에서 404 에러가 발견되어서 태그에 연동된 링크를 제거합니다.
Snippet 리스트에서도 블로그와 동일하게 readingTime을 보여줍니다.
프로필 사진을 누르면 바로 깃허브로 갈 수 있도록 링크를 등록합니다.

drop shadow를 오렌지 색으로 변경하고 SeriesCard의 마진을 조정했습니다.

## 🌱 작업사항
* 태그 컴포넌트 링크 제거
* Snippet 리스트에서 readingTime을 보여줍니다.
* 프로필 사진에 깃허브 링크 연동
* 강조에 사용되는 drop shadow를 오렌지 색으로 변경했습니다.
* SeriesCard의 마진을 조정했습니다.

## ✅ check list
- [x] 이슈 내용을 전부 적용했나요?
- [x] 산정한 작업 기간 내에 개발했나요?
