### PR TITLE
[FEAT][CHORE] next-sitemap 제거, sitemap 저장 위치 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && next-sitemap && next export",
-    "postBuild": "yarn sitemap",
+    "build": "next build && next export",
+    "postbuild": "yarn sitemap",
     "sitemap": "ts-node --project tsconfig.node.json ./scripts/generateSitemap.ts",
     "start": "next start",
     "postinstall": "husky install",

--- a/scripts/generateSitemap.ts
+++ b/scripts/generateSitemap.ts
@@ -21,7 +21,7 @@ ${PostJson.map(
 ).join('\n')}
 </urlset>`;
 
-  writeFileSync('out/sitemap.xml', sitemap, 'utf-8');
+  writeFileSync('public/sitemap.xml', sitemap, 'utf-8');
 };
 
 const createRobotsTxt = () => {
@@ -34,7 +34,7 @@ Sitemap: ${siteUrl}/sitemap.xml
 Host: ${siteUrl}
   `;
 
-  writeFileSync('out/robots.txt', text.trim(), 'utf-8');
+  writeFileSync('public/robots.txt', text.trim(), 'utf-8');
 };
 
 (() => {


### PR DESCRIPTION
## 🌱 개요
사용하지 않는 next-sitemap 명령어를 제거하고
배포 시에 sitemap.xml 파일에 접근할 수 있도록 public으로 저장 위치를 변경합니다.

## 🌱 작업사항
* next-sitemap 명령어 제거
* sitemap.xml 저장 위치 변경

## ✅ check list
- [x] 이슈 내용을 전부 적용했나요?
- [x] 산정한 작업 기간 내에 개발했나요?
