### PR TITLE
[CHORE] : sitemap 저장 위치 변경, contentlayer 빌드 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "postbuild": "yarn sitemap",
     "sitemap": "ts-node --project tsconfig.node.json ./scripts/generateSitemap.ts",
     "start": "next start",
-    "postinstall": "husky install",
+    "postinstall": "husky install && contentlayer build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --cache",
     "lint-staged": "lint-staged"
   },

--- a/scripts/generateSitemap.ts
+++ b/scripts/generateSitemap.ts
@@ -21,7 +21,7 @@ ${PostJson.map(
 ).join('\n')}
 </urlset>`;
 
-  writeFileSync('public/sitemap.xml', sitemap, 'utf-8');
+  writeFileSync('out/sitemap.xml', sitemap, 'utf-8');
 };
 
 const createRobotsTxt = () => {
@@ -34,7 +34,7 @@ Sitemap: ${siteUrl}/sitemap.xml
 Host: ${siteUrl}
   `;
 
-  writeFileSync('public/robots.txt', text.trim(), 'utf-8');
+  writeFileSync('out/robots.txt', text.trim(), 'utf-8');
 };
 
 (() => {


### PR DESCRIPTION
## 🌱 개요
- vercel 배포 시 contentlayer build > yarn build > yarn sitemap 의 순차적인 과정을 거쳐야합니다.
- 따라서 install 후에 바로 contentlayer를 build 할 수 있도록 추가해주었고
- sitemap 생성을 build 이후에 해주기 때문에 public이 아닌 out 폴더에 저장하도록 수정하였습니다.

## 🌱 작업사항
* postinstall에 contentlayer build 명령어 추가
* sitemap과 robots 파일을 out 폴더에 저장

## ✅ check list
- [x] 이슈 내용을 전부 적용했나요?
- [x] 산정한 작업 기간 내에 개발했나요?
