### PR TITLE
[FEAT] lighthouse 성능 개선을 위한 image 최적화, tap target 사이즈 조정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,4 +9,7 @@ module.exports = withContentlayer({
       { loader: '@next/font/google', options: { subsets: ['latin'] } },
     ],
   },
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
 });

--- a/public/images/favicon/manifest.json
+++ b/public/images/favicon/manifest.json
@@ -1,41 +1,29 @@
 {
- "name": "App",
- "icons": [
-  {
-   "src": "\/android-icon-36x36.png",
-   "sizes": "36x36",
-   "type": "image\/png",
-   "density": "0.75"
-  },
-  {
-   "src": "\/android-icon-48x48.png",
-   "sizes": "48x48",
-   "type": "image\/png",
-   "density": "1.0"
-  },
-  {
-   "src": "\/android-icon-72x72.png",
-   "sizes": "72x72",
-   "type": "image\/png",
-   "density": "1.5"
-  },
-  {
-   "src": "\/android-icon-96x96.png",
-   "sizes": "96x96",
-   "type": "image\/png",
-   "density": "2.0"
-  },
-  {
-   "src": "\/android-icon-144x144.png",
-   "sizes": "144x144",
-   "type": "image\/png",
-   "density": "3.0"
-  },
-  {
-   "src": "\/android-icon-192x192.png",
-   "sizes": "192x192",
-   "type": "image\/png",
-   "density": "4.0"
-  }
- ]
+  "name": "App",
+  "icons": [
+    {
+      "src": "/android-icon-36x36.png",
+      "sizes": "36x36",
+      "type": "image/png",
+      "density": "0.75"
+    },
+    {
+      "src": "/android-icon-48x48.png",
+      "sizes": "48x48",
+      "type": "image/png",
+      "density": "1.0"
+    },
+    {
+      "src": "/android-icon-72x72.png",
+      "sizes": "72x72",
+      "type": "image/png",
+      "density": "1.5"
+    },
+    {
+      "src": "/android-icon-96x96.png",
+      "sizes": "96x96",
+      "type": "image/png",
+      "density": "2.0"
+    }
+  ]
 }

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -52,8 +52,8 @@ export default function SearchInput({
   return (
     <form
       className={$(
-        'relative w-full flex items-center',
-        'w-full rounded-xl border px-4 py-2 w-[150px] sm:min-w-[200px]',
+        'relative w-full flex items-center gap-2',
+        'w-full rounded-xl border px-1 py-1 w-[150px] sm:min-w-[200px]',
         'border-neutral-200 bg-tertiary placeholder:text-tertiary dark:border-neutral-900 dark:bg-neutral-800',
         className,
       )}
@@ -62,7 +62,7 @@ export default function SearchInput({
       <input
         type="text"
         className={$(
-          'w-full bg-tertiary placeholder:text-mute dark:bg-neutral-800 focus:outline-none',
+          'w-full bg-tertiary placeholder:text-mute dark:bg-neutral-800 focus:outline-none pl-2',
         )}
         placeholder={placeholder}
         value={inputText}
@@ -73,21 +73,23 @@ export default function SearchInput({
       <button
         aria-label="search-button"
         type="submit"
-        className="text-secondary h-5 w-5 ml-1"
+        className="text-secondary w-[30px] h-[30px] flex justify-center items-center shrink-0"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-          />
-        </svg>
+        <div className="w-5 h-5">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+        </div>
       </button>
     </form>
   );

--- a/src/components/home/IntroduceInfo.tsx
+++ b/src/components/home/IntroduceInfo.tsx
@@ -12,12 +12,8 @@ export default function IntroduceInfo() {
       animate="animate"
       className="text-tertiary"
     >
-      <Title className="text-primary flex max-[410px]:flex-col">
-        <span className="mr-2 pb-1">기억은 기록을 이기지</span>
-        <span className="flex">
-          <span>못한다</span>
-          <span className="ml-2">✍️</span>
-        </span>
+      <Title className="text-black flex max-[410px]:flex-col">
+        <span className="pb-1">기억은 기록을 이기지 못한다 ✍️</span>
       </Title>
       <div className="pt-2 flex flex-col sm:flex-row justify-between">
         <div className="w-full h-full">

--- a/src/components/post/PostPressedCard.tsx
+++ b/src/components/post/PostPressedCard.tsx
@@ -36,6 +36,7 @@ export default function PostPressedCard({
                 height={300}
                 className={'h-64 w-full object-cover'}
                 draggable={false}
+                priority
               />
               <div className="p-6 sm:h-[128px]">
                 <div className="mb-2 flex w-full items-end">

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -25,8 +25,6 @@ export default function Document() {
         sizes="16x16"
         href="/images/favicon/favicon-16x16.png"
       />
-      <meta name="msapplication-TileColor" content="#ffffff" />
-      <meta name="msapplication-TileImage" content="/ms-icon-144x144.png" />
       <meta
         name="theme-color"
         content="#fafafa"


### PR DESCRIPTION
## 🌱 만들고자 하는 기능
- LCP 시간을 단축하기 위해 이미지 크기를 줄입니다.
   - 최우선으로 avif 형식을 사용하고 avif 형식 지원이 안된다면 webp 형식을 사용합니다.
- LCP 시간을 단축하기 위해 메인 페이지 이미지에 priority를 설정합니다.
- SEO 향상을 위해 tag target 사이즈 조정

## 🌱 구현 내용
- [ ] next.config.js에 avif, webp 설정 추가
- [ ] 메인 페이지 이미지에 priority 속성 추가
- [ ] tab을 충분히 할 수 있는 공간 확보
- [ ] 사용하지 않는 파일 제거

## ✅ check list
- [ ] 이슈 내용을 전부 적용했나요?
- [ ] 산정한 작업 기간 내에 개발했나요?
